### PR TITLE
Extract fragment parsing

### DIFF
--- a/src/Abstracts/AbstractQuery.php
+++ b/src/Abstracts/AbstractQuery.php
@@ -3,7 +3,7 @@
 namespace ElasticSearcher\Abstracts;
 
 use ElasticSearcher\ElasticSearcher;
-use ElasticSearcher\ResultParsers\ArrayResultParser;
+use ElasticSearcher\Parsers\ArrayResultParser;
 
 /**
  * Base class for queries.

--- a/src/Abstracts/AbstractQuery.php
+++ b/src/Abstracts/AbstractQuery.php
@@ -161,21 +161,10 @@ abstract class AbstractQuery
 			$query['type'] = implode(',', array_values($this->types));
 		}
 
-		$query['body'] = $this->parseFragments($this->body);
+		// Replace Fragments with their raw body.
+		$query['body'] = $this->fragmentParser->parse($this->body);
 
 		return $query;
-	}
-
-	/**
-	 * Replace fragments with their body.
-	 *
-	 * @param array $body
-	 *
-	 * @return array
-	 */
-	protected function parseFragments(array $body)
-	{
-		return $this->fragmentParser->parse($body);
 	}
 
 	/**

--- a/src/Abstracts/AbstractQuery.php
+++ b/src/Abstracts/AbstractQuery.php
@@ -4,6 +4,7 @@ namespace ElasticSearcher\Abstracts;
 
 use ElasticSearcher\ElasticSearcher;
 use ElasticSearcher\Parsers\ArrayResultParser;
+use ElasticSearcher\Parsers\FragmentParser;
 
 /**
  * Base class for queries.
@@ -49,6 +50,11 @@ abstract class AbstractQuery
 	protected $resultParser;
 
 	/**
+	 * @var FragmentParser
+	 */
+	protected $fragmentParser;
+
+	/**
 	 * Prepare the query. Add filters, sorting, ....
 	 */
 	abstract protected function setup();
@@ -62,6 +68,7 @@ abstract class AbstractQuery
 
 		// Default result parser.
 		$this->parseResultsWith(new ArrayResultParser());
+		$this->fragmentParser = new FragmentParser();
 	}
 
 	/**
@@ -91,7 +98,7 @@ abstract class AbstractQuery
 	/**
 	 * Search in an index and/or type.
 	 *
-	 * @param string      $index
+	 * @param string $index
 	 * @param null|string $type
 	 */
 	protected function searchIn($index, $type = null)
@@ -154,37 +161,21 @@ abstract class AbstractQuery
 			$query['type'] = implode(',', array_values($this->types));
 		}
 
-		$query['body'] = $this->parseAbstracts($this->body);
+		$query['body'] = $this->parseFragments($this->body);
 
 		return $query;
 	}
 
 	/**
-	 * Traverses the body and checks if there are any abstracts (filters, queries) to be replaced with their
-	 * body.
+	 * Replace fragments with their body.
 	 *
 	 * @param array $body
 	 *
 	 * @return array
 	 */
-	protected function parseAbstracts(array $body)
+	protected function parseFragments(array $body)
 	{
-		// Have we parsed something, we'll recursively keep parsing until this stays false.
-		$parsed = false;
-
-		// Replace all abstracts with their body.
-		array_walk_recursive($body, function (&$item) use (&$parsed) {
-			if ($item instanceof AbstractFragment) {
-				$item   = $item->getBody();
-				$parsed = true;
-			}
-		});
-
-		if ($parsed) {
-			$body = $this->parseAbstracts($body);
-		}
-
-		return $body;
+		return $this->fragmentParser->parse($body);
 	}
 
 	/**

--- a/src/Parsers/ArrayResultParser.php
+++ b/src/Parsers/ArrayResultParser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace ElasticSearcher\ResultParsers;
+namespace ElasticSearcher\Parsers;
 
 use ElasticSearcher\Abstracts\AbstractResultParser;
 
 /**
- * @package ElasticSearcher\ResultParsers
+ * @package ElasticSearcher\Parsers
  */
 class ArrayResultParser extends AbstractResultParser
 {

--- a/src/Parsers/FragmentParser.php
+++ b/src/Parsers/FragmentParser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ElasticSearcher\Parsers;
+
+use ElasticSearcher\Abstracts\AbstractFragment;
+
+/**
+ * Traverses an array and checks if there are any abstracts fragment to be replaced with their body.
+ *
+ * @package ElasticSearcher\Parsers
+ */
+class FragmentParser
+{
+	/**
+	 * @param array $body
+	 *
+	 * @return array
+	 */
+	public function parse(array $body)
+	{
+		// Have we parsed something, we'll recursively keep parsing until this stays false.
+		$parsed = false;
+
+		// Replace all abstracts with their body.
+		array_walk_recursive($body, function (&$item) use (&$parsed) {
+			if ($item instanceof AbstractFragment) {
+				$item = $item->getBody();
+				$parsed = true;
+			}
+		});
+
+		if ($parsed) {
+			$body = $this->parse($body);
+		}
+
+		return $body;
+	}
+}

--- a/tests/Parsers/FragmentParserTest.php
+++ b/tests/Parsers/FragmentParserTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use ElasticSearcher\Parsers\FragmentParser;
+use ElasticSearcher\Fragments\Filters\TermFilter;
+
+class FragmentParserTest extends ElasticSearcherTestCase
+{
+	public function testParsingRootLevel()
+	{
+		$parser = new FragmentParser();
+
+		$body = [
+			'query' => new TermFilter('name', 'John'),
+		];
+		$expectedBody = [
+			'query' => [
+				'term' => [
+					'name' => 'John',
+				]
+			]
+		];
+
+		$this->assertEquals($expectedBody, $parser->parse($body));
+	}
+
+	public function testParsingChildLevel()
+	{
+		$parser = new FragmentParser();
+
+		$body = [
+			'query' => [
+				'bool' => [
+					'and' => [
+						new TermFilter('name', 'John'),
+						new TermFilter('category', 'authors'),
+					]
+				]
+			]
+		];
+		$expectedBody = [
+			'query' => [
+				'bool' => [
+					'and' => [
+						[
+							'term' => [
+								'name' => 'John'
+							]
+						],
+						[
+							'term' => [
+								'category' => 'authors'
+							]
+						],
+					]
+				]
+			]
+		];
+
+		$this->assertEquals($expectedBody, $parser->parse($body));
+	}
+
+	public function testParsingNestedFragments()
+	{
+		$parser = new FragmentParser();
+
+		$body = [
+			'query' => [
+				'bool' => [
+					'and' => [
+						new TermFilter('name', new TermFilter('category', 'authors')),
+					]
+				]
+			]
+		];
+		$expectedBody = [
+			'query' => [
+				'bool' => [
+					'and' => [
+						[
+							'term' => [
+								'name' => [
+									'term' => [
+										'category' => 'authors'
+									]
+								]
+							]
+						],
+					]
+				]
+			]
+		];
+
+		$this->assertEquals($expectedBody, $parser->parse($body));
+	}
+}


### PR DESCRIPTION
Not really sure about the creating of an `FragmentParser` instance in the `AbstractQuery` constructor, but there is no way to really inject it. I could also use a `parseFragmentsWith` so it can be overwritten (for tests for example), but there isn't a real life use case for opening it up the outside world.

Also tried to find a common ground for the `FragmentParser` and the `ArrayResultsParser` but they are so different in context that it doesn't help either of them to follow an interface.

Closes #15 
