### PR TITLE
Sorting: allow fields without direction

### DIFF
--- a/tests/Fragments/Traits/SortableTraitTest.php
+++ b/tests/Fragments/Traits/SortableTraitTest.php
@@ -9,14 +9,14 @@ class SortableTraitTest extends ElasticSearcherTestCase
 		$this->hasSort(
 			[
 				'sort_fields' => [
-					'name' => 'asc',
+					'name',
 					'age' => ['order' => 'asc', 'mode' => 'avg'],
 					'date' => 'asc',
 				]
 			],
 			null,
 			[
-				['name' => 'asc'],
+				'name',
 				['age' => ['order' => 'asc', 'mode' => 'avg']],
 				['date' => 'asc'],
 			]
@@ -69,6 +69,72 @@ class SortableTraitTest extends ElasticSearcherTestCase
 				['name' => 'asc'],
 				['age' => ['order' => 'asc', 'mode' => 'avg']],
 				['date' => 'asc'],
+			]
+		);
+	}
+
+	public function testSortingAFieldWithoutSortDirection()
+	{
+		$fields = [
+			'sort_fields' => [
+				'name',
+				'age' => ['order' => 'asc', 'mode' => 'avg'],
+				'date' => 'desc',
+			]
+		];
+
+		$this->hasSort(
+			$fields,
+			['sort' => 'date', 'sort_direction' => null],
+			[
+				['date' => 'desc'],
+				'name',
+				['age' => ['order' => 'asc', 'mode' => 'avg']],
+			]
+		);
+		$this->hasSort(
+			$fields,
+			['sort' => 'age', 'sort_direction' => null],
+			[
+				['age' => ['order' => 'asc', 'mode' => 'avg']],
+				'name',
+				['date' => 'desc'],
+			]
+		);
+	}
+
+	public function testSortingAFieldWithoutPredefinedDirection()
+	{
+		$fields = [
+			'sort_fields' => [
+				'name',
+				'age' => ['order' => 'asc', 'mode' => 'avg'],
+				'date' => 'desc',
+			]
+		];
+
+		$this->hasSort(
+			[
+				'sort_fields' => [
+					'name',
+					'age' => ['order' => 'asc', 'mode' => 'avg'],
+					'date' => 'desc',
+				]
+			],
+			['sort' => 'name'],
+			[
+				'name',
+				['age' => ['order' => 'asc', 'mode' => 'avg']],
+				['date' => 'desc'],
+			]
+		);
+		$this->hasSort(
+			$fields,
+			['sort' => 'name', 'sort_direction' => 'desc'],
+			[
+				['name' => 'desc'],
+				['age' => ['order' => 'asc', 'mode' => 'avg']],
+				['date' => 'desc'],
 			]
 		);
 	}


### PR DESCRIPTION
### Changed

* Sorting: add support for fields without a direction
* Sorting: use original field definition if no direction is provided (closes #31)

-- 

[Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html) supports 3 formats for sorting fields:

```json
[
    {"post_date" : {"order" : "asc"}},
    "user",
    {"name" : "desc" }
]
```

This package now supports all 3 fields when you do:

```php
$this->sortOn('post_date', 'desc');
[
    {"post_date" : {"order" : "desc"}},
    "user",
    {"name" : "desc" }
]
```

```php
$this->sortOn('name', 'asc');
[
    {"name" : "asc" },
    {"post_date" : {"order" : "desc"}},
    "user",
]
```

```php
$this->sortOn('user', 'asc');
[
    {"user" : "asc" }
    {"post_date" : {"order" : "desc"}},
    {"name" : "desc" }
]
```

```php
$this->sortOn('user');
[
    "user",
    {"post_date" : {"order" : "desc"}},
    {"name" : "desc" }
]
```