### PR TITLE
Fix merging multiple fragments

### DIFF
--- a/src/Parsers/FragmentParser.php
+++ b/src/Parsers/FragmentParser.php
@@ -25,8 +25,8 @@ class FragmentParser
 
 					// Add the parsed fragment to the parent.
 					if ($item->mergeWithParent) {
-						$body = array_merge($body, $parsedBody);
 						unset($body[$key]);
+						$body = array_merge($body, $parsedBody);
 					} // Replace its current position with the parsed fragment.
 					else {
 						$item = $parsedBody;

--- a/tests/Parsers/FragmentParserTest.php
+++ b/tests/Parsers/FragmentParserTest.php
@@ -115,6 +115,34 @@ class FragmentParserTest extends ElasticSearcherTestCase
 		$this->assertEquals($expectedBody, $parser->parse($body));
 	}
 
+	public function testParsingAndMergingMultipleFragmentsWithParent()
+	{
+		$parser = new FragmentParser();
+
+		$body = [
+			'settings' => [
+				new StandardAnalyzer('myAnalyzer1'),
+				new StandardAnalyzer('myAnalyzer2'),
+				new StandardAnalyzer('myAnalyzer3'),
+			]
+		];
+		$expectedBody = [
+			'settings' => [
+				'myAnalyzer1' => [
+					'type' => 'standard'
+				],
+				'myAnalyzer2' => [
+					'type' => 'standard'
+				],
+				'myAnalyzer3' => [
+					'type' => 'standard'
+				]
+			]
+		];
+
+		$this->assertEquals($expectedBody, $parser->parse($body));
+	}
+
 	public function testParsingCustomFragments()
 	{
 		$parser = new FragmentParser();


### PR DESCRIPTION
array_merge changes numeric keys, so if you don't unset before the merge, you
risk unsetting the wrong key.

The new test fails before the change to parse(...), and all tests pass after it.