### PR TITLE
Stop PaginatedTrait setting minus "from" values

### DIFF
--- a/src/Fragments/Traits/PaginatedTrait.php
+++ b/src/Fragments/Traits/PaginatedTrait.php
@@ -17,7 +17,7 @@ trait PaginatedTrait
 	 */
 	public function paginate($page, $perPage = 30)
 	{
-		$this->set('from', ($perPage * ($page - 1)));
+		$this->set('from', max(0, $perPage * ($page - 1)));
 		$this->set('size', $perPage);
 
 		return $this;

--- a/tests/Fragments/Traits/PaginatedTraitTest.php
+++ b/tests/Fragments/Traits/PaginatedTraitTest.php
@@ -15,4 +15,15 @@ class PaginatedTraitTest extends ElasticSearcherTestCase
 		$this->assertEquals('20', $raw['from']);
 		$this->assertEquals('10', $raw['size']);
 	}
+
+	public function testPaginatingWithPageZero()
+  {
+    $query = new PaginatedMoviesFrom2014Query($this->getElasticSearcher(), 0);
+    $query->paginate(0, 10);
+
+    $raw = $query->getRawQuery()['body'];
+
+    $this->assertEquals('0', $raw['from']);
+    $this->assertEquals('10', $raw['size']);
+  }
 }

--- a/tests/Fragments/Traits/PaginatedTraitTest.php
+++ b/tests/Fragments/Traits/PaginatedTraitTest.php
@@ -17,13 +17,14 @@ class PaginatedTraitTest extends ElasticSearcherTestCase
 	}
 
 	public function testPaginatingWithPageZero()
-  {
-    $query = new PaginatedMoviesFrom2014Query($this->getElasticSearcher(), 0);
-    $query->paginate(0, 10);
+	{
+		$query = new PaginatedMoviesFrom2014Query($this->getElasticSearcher());
+		$query->addData(['page' => 0]);
+		$query->paginate(0, 10);
 
-    $raw = $query->getRawQuery()['body'];
+		$raw = $query->getRawQuery()['body'];
 
-    $this->assertEquals('0', $raw['from']);
-    $this->assertEquals('10', $raw['size']);
-  }
+		$this->assertEquals('0', $raw['from']);
+		$this->assertEquals('10', $raw['size']);
+	}
 }

--- a/tests/dummy/Queries/PaginatedMoviesFrom2014Query.php
+++ b/tests/dummy/Queries/PaginatedMoviesFrom2014Query.php
@@ -10,16 +10,9 @@ class PaginatedMoviesFrom2014Query extends AbstractQuery
 {
 	use PaginatedTrait;
 
-	private $pageNumber;
-
-	public function __construct(\ElasticSearcher\ElasticSearcher $searcher, $page = 3)
-  {
-    parent::__construct($searcher);
-    $this->pageNumber = $page;
-  }
-
-  public function setup()
+	public function setup()
 	{
-		$this->paginate($this->pageNumber, 10);
+		$page = isset($this->data['page']) ? $this->data['page'] : 3;
+		$this->paginate($page, 10);
 	}
 }

--- a/tests/dummy/Queries/PaginatedMoviesFrom2014Query.php
+++ b/tests/dummy/Queries/PaginatedMoviesFrom2014Query.php
@@ -3,14 +3,23 @@
 namespace ElasticSearcher\Dummy\Queries;
 
 use ElasticSearcher\Abstracts\AbstractQuery;
+use ElasticSearcher\ElasticSearcher;
 use ElasticSearcher\Fragments\Traits\PaginatedTrait;
 
 class PaginatedMoviesFrom2014Query extends AbstractQuery
 {
 	use PaginatedTrait;
 
-	public function setup()
+	private $pageNumber;
+
+	public function __construct(\ElasticSearcher\ElasticSearcher $searcher, $page = 3)
+  {
+    parent::__construct($searcher);
+    $this->pageNumber = $page;
+  }
+
+  public function setup()
 	{
-		$this->paginate(3, 10);
+		$this->paginate($this->pageNumber, 10);
 	}
 }


### PR DESCRIPTION
This is more just hardening than anything else. If you pass in `$page` as 0 currently, you will end up with a minus value (depending of what the size is). This just makes sure it's `0` or above.