### PR TITLE
Replace illuminate/support with jdrieghe/array-helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require": {
 		"elasticsearch/elasticsearch": "^5.1",
-		"illuminate/support": "^4.2|~5"
+		"jdrieghe/array-helpers": "^0.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"

--- a/src/Abstracts/AbstractQuery.php
+++ b/src/Abstracts/AbstractQuery.php
@@ -2,11 +2,11 @@
 
 namespace ElasticSearcher\Abstracts;
 
+use ArrayHelpers\Arr;
 use ElasticSearcher\ElasticSearcher;
 use ElasticSearcher\Parsers\ArrayResultParser;
 use ElasticSearcher\Parsers\FragmentParser;
 use ElasticSearcher\Traits\BodyTrait;
-use Illuminate\Support\Arr;
 
 /**
  * Base class for queries.

--- a/src/Abstracts/AbstractResultParser.php
+++ b/src/Abstracts/AbstractResultParser.php
@@ -2,7 +2,7 @@
 
 namespace ElasticSearcher\Abstracts;
 
-use Illuminate\Support\Arr;
+use ArrayHelpers\Arr;
 
 /**
  * Base class for result parsing.

--- a/src/Traits/BodyTrait.php
+++ b/src/Traits/BodyTrait.php
@@ -2,7 +2,7 @@
 
 namespace ElasticSearcher\Traits;
 
-use Illuminate\Support\Arr;
+use ArrayHelpers\Arr;
 
 /**
  * A body can be an entire query or just a chunk of query (fragment).

--- a/tests/Managers/IndicesManagerTest.php
+++ b/tests/Managers/IndicesManagerTest.php
@@ -65,7 +65,11 @@ class IndicesManagerTest extends ElasticSearcherTestCase
 		$expectedIndex = ['authors' => ['mappings' => $authorsIndex->getTypes()]];
 		$this->assertEquals($expectedIndex, $this->indicesManager->get('authors'));
 
-		$expectedIndex = ['authors' => ['mappings' => array_only($authorsIndex->getTypes(), 'producers')]];
+		$expectedIndex = [
+			'authors' => [
+			    'mappings' => array_intersect_key($authorsIndex->getTypes(), array_flip((array) 'producers')),
+            ],
+		];
 		$this->assertEquals($expectedIndex, $this->indicesManager->getType('authors', 'producers'));
 	}
 


### PR DESCRIPTION
### Added
- `jdrieghe/array-helpers` dependency

### Removed
- `illuminate/support` dependency

---
Resolves https://github.com/madewithlove/elasticsearcher/issues/40