### PR TITLE
Use getBody Method When Calling get in BodyTrait

### DIFF
--- a/src/Traits/BodyTrait.php
+++ b/src/Traits/BodyTrait.php
@@ -61,6 +61,6 @@ trait BodyTrait
 	 */
 	public function get($key, $default = null)
 	{
-		return Arr::get($this->body, $key, $default);
+		return Arr::get($this->getBody(), $key, $default);
 	}
 }

--- a/tests/Managers/IndicesManagerTest.php
+++ b/tests/Managers/IndicesManagerTest.php
@@ -55,6 +55,12 @@ class IndicesManagerTest extends ElasticSearcherTestCase
 		$this->assertTrue($this->indicesManager->existsType('authors', 'producers'));
 	}
 
+    public function testUpdating()
+    {
+        $this->indicesManager->create('authors');
+        $this->indicesManager->update('authors');
+    }
+
 	public function testGetting()
 	{
 		$this->indicesManager->create('authors');

--- a/tests/Traits/BodyTraitTest.php
+++ b/tests/Traits/BodyTraitTest.php
@@ -14,4 +14,14 @@ class BodyTraitTest extends ElasticSearcherTestCase
 		$mock->set('key.nested', 'value');
 		$this->assertEquals(['key' => ['nested' => 'value']], $mock->getBody());
 	}
+
+	public function testGet()
+	{
+		$mock = $this->getMockForTrait(BodyTrait::class, [], '', true, true, true, ['getBody']);
+		$mock->expects($this->once())
+			->method('getBody')
+			->willReturn(['key' => 'value']);
+
+		$this->assertSame('value', $mock->get('key'));
+	}
 }


### PR DESCRIPTION
The `BodyTrait` currently uses the `$body` property directly when `get` is called. This is fine for most cases. However, `AbstractIndex` overrides the `getBody` method to parse the body with the fragment parser.

I discovered this when looking into why index updates don't work. It is because `IndicesManager::update()` uses the following code:
```php
foreach ($index->getTypes() as $type => $typeBody) {
	$params = [
		'index' => $index->getInternalName(),
		'type'  => $type,
		'body'  => [$type => $typeBody]
	];

	$this->elasticSearcher->getClient()->indices()->putMapping($params);
}
```

`getTypes` calls `get('mappings')`, which in turn gets the un-parsed body instead of the parsed body. With this change, I can use the `update` method fine (Within the ES limitation of index updating, of course).